### PR TITLE
Handle case where find_source_file fails

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -35,10 +35,13 @@ function whereis(method::Method)
         file, line = fileline(lin[1])
     end
     if !isabspath(file)
-        # This is a Base or Core method
-        file = Base.find_source_file(file)
+        # This may be a Base or Core method
+        newfile = Base.find_source_file(file)
+        if isa(newfile, AbstractString)
+            file = normpath(newfile)
+        end
     end
-    return normpath(file), line
+    return file, line
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,4 +42,10 @@ include("script.jl")
 
     @test pkgfiles("ColorTypes") === nothing
     @test_throws ErrorException pkgfiles("NotAPkg")
+
+    # Test that definitions at the REPL work with `whereis`
+    ex = Base.parse_input_line("replfunc(x) = 1"; filename="REPL[1]")
+    eval(ex)
+    m = first(methods(replfunc))
+    @test whereis(m) == ("REPL[1]", 1)
 end


### PR DESCRIPTION
This was throwing errors for methods defined at the REPL.