### PR TITLE
Implement signatures_at

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ julia> definition(m, String)
 "red(c::AbstractRGB   ) = c.r\n"
 ```
 
+or to find the method-signatures at a particular location:
+
+```julia
+julia> signatures_at(ColorTypes, "src/traits.jl", 14)
+1-element Array{Any,1}:
+ Tuple{typeof(red),AbstractRGB}
+
+julia> signatures_at("/home/tim/.julia/packages/ColorTypes/BsAWO/src/traits.jl", 14)
+1-element Array{Any,1}:
+ Tuple{typeof(red),AbstractRGB}
+```
+
 ## A few details
 
 CodeTracking won't do anything *useful* unless the user is also running Revise,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+# Note: some of CodeTracking's functionality can only be tested by Revise
+
 using CodeTracking
 using Test
 # Note: ColorTypes needs to be installed, but note the intentional absence of `using ColorTypes`


### PR DESCRIPTION
This allows one to find the methods defined by a particular block of code. One subtlety here is that multiple methods might be defined if the file/line combination points to a method with default arguments, keyword arguments, and the like. Note that not all of these methods are guaranteed to even have the same name.

I also contemplated calling this `methods_at`, but that can be obtained from `signatures_at` followed by call(s) to `which` (or better, `whichtt` in JuliaInterpreter). Since `which` is slow, I thought it would be better to return just the most essential information.

Closes #3.