### PR TITLE
Allow marking of methods as missing

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -14,7 +14,7 @@ include("utils.jl")
 
 # These values get populated by Revise
 
-const method_info = IdDict{Type,Tuple{LineNumberNode,Expr}}()
+const method_info = IdDict{Type,Union{Missing,Tuple{LineNumberNode,Expr}}}()
 
 const _pkgfiles = Dict{PkgId,PkgFiles}()
 
@@ -41,7 +41,7 @@ function whereis(method::Method)
             end
         end
     end
-    if lin === nothing
+    if lin === nothing || ismissing(lin)
         file, line = String(method.file), method.line
     else
         file, line = fileline(lin[1])
@@ -189,7 +189,7 @@ function definition(method::Method, ::Type{Expr})
             end
         end
     end
-    return def === nothing ? nothing : copy(def[2])
+    return def === nothing || ismissing(def) ? nothing : copy(def[2])
 end
 
 definition(method::Method) = definition(method, Expr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 # Note: some of CodeTracking's functionality can only be tested by Revise
 
 using CodeTracking
-using Test
+using Test, InteractiveUtils
 # Note: ColorTypes needs to be installed, but note the intentional absence of `using ColorTypes`
 
 include("script.jl")
@@ -44,6 +44,12 @@ include("script.jl")
 
     @test pkgfiles("ColorTypes") === nothing
     @test_throws ErrorException pkgfiles("NotAPkg")
+
+    # Test a method marked as missing
+    m = @which sum(1:5)
+    CodeTracking.method_info[m.sig] = missing
+    @test whereis(m) == (CodeTracking.maybe_fix_path(String(m.file)), m.line)
+    @test definition(m) === nothing
 
     # Test that definitions at the REPL work with `whereis`
     ex = Base.parse_input_line("replfunc(x) = 1"; filename="REPL[1]")


### PR DESCRIPTION
This allows Revise to prevent re-execution of `method_lookup_callback[]` by indicating that the method definition is not available.