### PR TITLE
signatures_at support for Base, stdlibs, and methods defined at the REPL

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -18,8 +18,23 @@ const method_info = IdDict{Type,Union{Missing,Tuple{LineNumberNode,Expr}}}()
 
 const _pkgfiles = Dict{PkgId,PkgFiles}()
 
+# Callback for method-lookup. `lookupfunc = method_lookup_callback[]` must have the form
+#     ret = lookupfunc(method)
+# where `ret` is either `nothing` or `(lnn, def)`. `lnn` is a LineNumberNode (or any valid
+# input to `CodeTracking.fileline`) and `def` is the expression defining the method.
 const method_lookup_callback = Ref{Any}(nothing)
-const expressions_callback   = Ref{Any}(nothing)
+
+# Callback for `signatures_at` (lookup by file/lineno). `lookupfunc = expressions_callback[]`
+# must have the form
+#    mod, exsigs = lookupfunc(id, relpath)
+# where
+#    id is the PkgId of the corresponding package
+#    relpath is the path of the file from the basedir of `id`
+#    mod is the "active" module at that point in the source
+#    exsigs is a ex=>sigs dictionary, where `ex` is the source expression and `sigs`
+#        a list of method-signatures defined by that expression.
+const expressions_callback = Ref{Any}(nothing)
+
 
 ### Public API
 

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -126,6 +126,10 @@ function signatures_at(filename::AbstractString, line::Integer)
         id = PkgId(Base.project_deps_get(project, libname), libname)
         return signatures_at(id, joinpath(spath[2:end]...), line)
     end
+    if startswith(filename, "REPL[")
+        id = PkgId("@REPL")
+        return signatures_at(id, filename, line)
+    end
     for (id, pkgfls) in _pkgfiles
         if startswith(filename, basedir(pkgfls)) || id.name == "Main"
             bdir = basedir(pkgfls)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -81,3 +81,11 @@ function maybe_fixup_stdlib_path(path)
     end
     return path
 end
+
+function postpath(filename, pre)
+    idx = findfirst(pre, filename)
+    idx === nothing && error(pre, " not found in ", filename)
+    post = filename[first(idx) + length(pre) : end]
+    post[1:1] == Base.Filesystem.path_separator && return post[2:end]
+    return post
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,3 +75,17 @@ include("script.jl")
     file, line = whereis(lin, m)
     @test endswith(file, String(lin.file))
 end
+
+@testset "With Revise" begin
+    if isdefined(Main, :Revise)
+        m = @which gcd(10, 20)
+        sigs = signatures_at(Base.find_source_file(String(m.file)), m.line)
+        @test !isempty(sigs)
+
+        m = first(methods(edit))
+        sigs = signatures_at(String(m.file), m.line)
+        @test !isempty(sigs)
+        sigs = signatures_at(Base.find_source_file(String(m.file)), m.line)
+        @test !isempty(sigs)
+    end
+end


### PR DESCRIPTION
This may require https://github.com/timholy/Revise.jl/pull/243 to actually work (not certain, it might be OK without).