### PR TITLE
Change the API on `definition(::Method, String)`

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -175,9 +175,10 @@ function signatures_at(id::PkgId, relpath::AbstractString, line::Integer)
 end
 
 """
-    src = definition(method::Method, String)
+    src, line1 = definition(method::Method, String)
 
-Return a string with the code that defines `method`.
+Return a string with the code that defines `method`. Also return the first line of the
+definition, including the signature.
 
 Note this may not be terribly useful for methods that are defined inside `@eval` statements;
 see [`definition(method::Method, Expr)`](@ref) instead.
@@ -194,7 +195,7 @@ function definition(method::Method, ::Type{String})
     end
     ex, iend = Meta.parse(src, istart)
     if isfuncexpr(ex)
-        return src[istart+1:iend-1]
+        return src[istart+1:iend-1], line
     end
     # The function declaration was presumably on a previous line
     lineindex = lastindex(linestarts)
@@ -204,7 +205,7 @@ function definition(method::Method, ::Type{String})
         lineindex -= 1
         line -= 1
     end
-    return src[istart:iend-1]
+    return src[istart:iend-1], line
 end
 
 """

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -198,9 +198,11 @@ function definition(method::Method, ::Type{String})
     end
     # The function declaration was presumably on a previous line
     lineindex = lastindex(linestarts)
-    while !isfuncexpr(ex)
+    while !isfuncexpr(ex) && lineindex > 0
         istart = linestarts[lineindex]
         ex, iend = Meta.parse(src, istart)
+        lineindex -= 1
+        line -= 1
     end
     return src[istart:iend-1]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,19 +20,21 @@ isdefined(Main, :Revise) ? includet("script.jl") : include("script.jl")
     @test whereis(trace[2]) == (scriptpath, 11)
     @test whereis(trace[3]) === nothing
 
-    src = definition(m, String)
+    src, line = definition(m, String)
     @test src == """
     function f1(x, y)
         # A comment
         return x + y
     end
     """
+    @test line == 2
 
     m = first(methods(f2))
-    src = definition(m, String)
+    src, line = definition(m, String)
     @test src == """
     f2(x, y) = x + y
     """
+    @test line == 7
 
     info = CodeTracking.PkgFiles(Base.PkgId(CodeTracking))
     @test Base.PkgId(info) === info.id

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,18 +11,19 @@ isdefined(Main, :Revise) ? includet("script.jl") : include("script.jl")
     file, line = whereis(m)
     scriptpath = normpath(joinpath(@__DIR__, "script.jl"))
     @test file == scriptpath
-    @test line == 3
+    @test line == 4
     trace = try
         call_throws()
     catch
         stacktrace(catch_backtrace())
     end
-    @test whereis(trace[2]) == (scriptpath, 10)
+    @test whereis(trace[2]) == (scriptpath, 11)
     @test whereis(trace[3]) === nothing
 
     src = definition(m, String)
     @test src == """
     function f1(x, y)
+        # A comment
         return x + y
     end
     """

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,5 +1,6 @@
 # NOTE: tests are sensitive to the line number at which statements appear
 function f1(x, y)
+    # A comment
     return x + y
 end
 


### PR DESCRIPTION
The String variant of `definition` has the ability to back up in the source file to also extract the signature. As a consequence, it may be unclear how the first line of the string corresponds to the output of `whereis`. To resolve the uncertainty, return the first source line as a second argument from `definition(::Method, String)`.

This is a breaking change; this will become CodeTracking v0.4.0.
