### PR TITLE
 Avoid abspath for REPL-defined "paths" 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ notifications:
 script:
     - export JULIA_PROJECT=""
     - julia --project -e 'using Pkg; Pkg.build(); Pkg.test();'
+    - julia -e 'using Pkg; Pkg.develop(PackageSpec(path="."));
+                           Pkg.add(PackageSpec(url="https://github.com/timholy/Revise.jl"));
+                           Pkg.test("Revise")'
 
 after_success:
   - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -115,7 +115,7 @@ Returns `nothing` if there are no methods at that location.
 """
 function signatures_at(filename::AbstractString, line::Integer)
     if !startswith(filename, "REPL[")
-        filename =  abspath(filename)
+        filename = abspath(filename)
     end
     if occursin(juliabase, filename)
         rpath = postpath(filename, juliabase)
@@ -188,17 +188,18 @@ see [`definition(Expr, method::Method)`](@ref) instead.
 """
 function definition(::Type{String}, method::Method)
     file, line = whereis(method)
-    src = read(file, String)
+    src = src_from_file_or_REPL(file)
     eol = isequal('\n')
     linestarts = Int[]
-    istart = 0
+    istart = 1
     for i = 1:line-1
-        push!(linestarts, istart+1)
-        istart = findnext(eol, src, istart+1)
+        push!(linestarts, istart)
+        istart = findnext(eol, src, istart) + 1
     end
     ex, iend = Meta.parse(src, istart)
     if isfuncexpr(ex)
-        return src[istart+1:iend-1], line
+        iend = min(iend, lastindex(src))
+        return strip(src[istart:iend], '\n'), line
     end
     # The function declaration was presumably on a previous line
     lineindex = lastindex(linestarts)

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -114,7 +114,9 @@ Return the signatures of all methods whose definition spans the specified locati
 Returns `nothing` if there are no methods at that location.
 """
 function signatures_at(filename::AbstractString, line::Integer)
-    filename = abspath(filename)
+    if !startswith(filename, "REPL[")
+        filename =  abspath(filename)
+    end
     if occursin(juliabase, filename)
         rpath = postpath(filename, juliabase)
         id = PkgId(Base)


### PR DESCRIPTION
Argh, in fixing #23 I broke other stuff. So we should start running the Revise tests here.

Also fixes #28.