### PR TITLE
Strip macros in `definition(String, m)`

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -2,6 +2,7 @@ module CodeTracking
 
 using Base: PkgId
 using Core: LineInfoNode
+using Base.Meta: isexpr
 using UUIDs
 using InteractiveUtils
 
@@ -203,9 +204,16 @@ function definition(::Type{String}, method::Method)
     end
     # The function declaration was presumably on a previous line
     lineindex = lastindex(linestarts)
+    local istart_noerr
     while !isfuncexpr(ex) && lineindex > 0
         istart = linestarts[lineindex]
-        ex, iend = Meta.parse(src, istart)
+        try
+            ex, iend = Meta.parse(src, istart)
+        catch
+            istart = istart_noerr
+            break
+        end
+        istart_noerr = istart
         lineindex -= 1
         line -= 1
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,9 @@
 function isfuncexpr(ex)
+    # Strip any macros that wrap the method definition
+    while isexpr(ex, :macrocall)
+        ex = ex.args[3]
+    end
+    isa(ex, Expr) || return false
     ex.head == :function && return true
     if ex.head == :(=)
         a = ex.args[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ isdefined(Main, :Revise) ? includet("script.jl") : include("script.jl")
     catch
         stacktrace(catch_backtrace())
     end
-    @test whereis(trace[2]) == (scriptpath, 11)
+    @test whereis(trace[2]) == (scriptpath, 9)
     @test whereis(trace[3]) === nothing
 
     src, line = definition(String, m)
@@ -32,6 +32,11 @@ isdefined(Main, :Revise) ? includet("script.jl") : include("script.jl")
     m = first(methods(f2))
     src, line = definition(String, m)
     @test src == "f2(x, y) = x + y"
+    @test line == 14
+
+    m = first(methods(throws))
+    src, line = definition(String, m)
+    @test startswith(src, "@noinline")
     @test line == 7
 
     info = CodeTracking.PkgFiles(Base.PkgId(CodeTracking))

--- a/test/script.jl
+++ b/test/script.jl
@@ -4,11 +4,11 @@ function f1(x, y)
     return x + y
 end
 
-f2(x, y) = x + y
-
 @noinline function throws()
     x = nothing
     error("oops")
 end
 @inline inlined() = throws()
 call_throws() = inlined()
+
+f2(x, y) = x + y


### PR DESCRIPTION
This will run into problems for macros that create methods, but that's problematic anyway.

Fixes #31