### PR TITLE
Strip final line endings (fix #42)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+environment:
+  matrix:
+  - julia_version: 1.0
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -215,7 +215,7 @@ function definition(::Type{String}, method::Method)
         lineindex -= 1
         line -= 1
     end
-    return src[istart:iend-1], line
+    return chomp(src[istart:iend-1]), line
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,12 +21,12 @@ isdefined(Main, :Revise) ? includet("script.jl") : include("script.jl")
     @test whereis(trace[3]) === nothing
 
     src, line = definition(String, m)
-    @test src == """
+    @test src == chomp("""
     function f1(x, y)
         # A comment
         return x + y
     end
-    """
+    """)
     @test line == 2
 
     m = first(methods(f2))


### PR DESCRIPTION
Is this change sufficiently breaking that we need to bump the minor version number? (We don't have the equivalent of `Pkg.dependents` yet, do we?)