### PR TITLE
make kwarg-methods whereis as nothing, rather than as ("none",0)

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -188,7 +188,7 @@ end
 Return a string with the code that defines `method`. Also return the first line of the
 definition, including the signature (which may not be the same line number returned
 by `whereis`).
-If the method could not be found for some reason, returns `nothing`.
+If the method could not be found for some reason, then return `nothing`.
 
 Note this may not be terribly useful for methods that are defined inside `@eval` statements;
 see [`definition(Expr, method::Method)`](@ref) instead.

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -46,7 +46,7 @@ const juliastdlib = joinpath("julia", "stdlib", "v$(VERSION.major).$(VERSION.min
 
 Return the file and line of the definition of `method`. `line`
 is the first line of the method's body.
-If for some reason the file can not be determined, then this returns `nothing`
+If for some reason the file can not be determined, then return `nothing`
 """
 function whereis(method::Method)
     method.file == :none && return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,14 @@ isdefined(Main, :Revise) ? includet("script.jl") : include("script.jl")
     lin = src.linetable[idx]
     file, line = whereis(lin, m)
     @test endswith(file, String(lin.file))
+
+
+    # kwargs that result in not finding the file
+    m = @which sum([1]; dims=1)
+    loc = whereis(m)
+    @test loc != ("none", 0)  # old incorrect behavour.
+    @test loc === nothing
+    @test definition(String, m) === nothing
 end
 
 @testset "With Revise" begin


### PR DESCRIPTION
Before:

```
julia> whereis(@which sum([1]; dims=1))
("none", 0)

julia> definition(String, @which sum([1]; dims=1))
ERROR: SystemError: opening file "none": No such file or directory
```

After, both of these return `nothing`.