### PR TITLE
Eliminate an ambiguity with JuliaInterpreter's `whereis` methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CodeTracking"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.0.4"
+version = "1.0.5"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -98,7 +98,7 @@ Return the file and line number associated with a specific statement in `method`
 `lineinfo.line` should contain the line number of the statement at the time `method`
 was compiled. The current location is returned.
 """
-function whereis(lineinfo, method::Method)
+function whereis(lineinfo::Union{LineNumberNode,StackTraces.StackFrame}, method::Method)
     file, line1 = whereis(method)
     # We could be in an expanded macro. Apply the correction only if the filename checks out.
     # (We're not super-fastidious here because of symlinks and other path ambiguities)


### PR DESCRIPTION
Given that this method expects a `line` field, it seems to make sense to
restrict the types here. However, in principle this could be breaking. Any concerns?

xref: https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/2f5f80034bc287a60fe77c4e3b5a49a087e38f8b/src/utils.jl#L318-L325

Kind of amazing this hasn't come up before.