### PR TITLE
Fix `definition` for return-type annotations

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,7 +2,7 @@
 # (or change the test)
 function checkname(fdef::Expr, name)
     fproto = fdef.args[1]
-    fdef.head === :where && return checkname(fproto, name)
+    (fdef.head === :where || fdef.head == :(::)) && return checkname(fproto, name)
     fdef.head === :call || return false
     if fproto isa Expr
         # A metaprogramming-generated function

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,12 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     @test occursin("100x", src)
     @test line == 22
 
+    # Issue #81
+    m = which(hasrettype, (Int,))
+    src, line = definition(String, m)
+    @test occursin("Float32", src)
+    @test line == 43
+
     info = CodeTracking.PkgFiles(Base.PkgId(CodeTracking))
     @test Base.PkgId(info) === info.id
     @test CodeTracking.basedir(info) == dirname(@__DIR__)

--- a/test/script.jl
+++ b/test/script.jl
@@ -38,3 +38,8 @@ function Foo.Bar.fit(m)
 end
 
 Foo.Bar.fit(a, b) = a + b
+
+# Issue #81
+function hasrettype(x::Real)::Float32
+    return x*x + x
+end


### PR DESCRIPTION
Fixes #81