### PR TITLE
let code_string return nothing if definition returns nothing

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -298,11 +298,7 @@ Returns the code-string for the method definition for `f` with the specified typ
 """
 function code_string(f, t)
     def = definition(String, which(f, t))
-    if def === nothing
-        return nothing
-    else
-        return def[1]
-    end
+    return def === nothing ? nothing : def[1]
 end
 macro code_string(ex0...)
     InteractiveUtils.gen_call_with_extracted_types_and_kwargs(__module__, :code_string, ex0)

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -296,7 +296,14 @@ end
 
 Returns the code-string for the method definition for `f` with the specified types.
 """
-code_string(f, t) = definition(String, which(f, t))[1]
+function code_string(f, t)
+    def = definition(String, which(f, t))
+    if def === nothing
+        return nothing
+    else
+        return def[1]
+    end
+end
 macro code_string(ex0...)
     InteractiveUtils.gen_call_with_extracted_types_and_kwargs(__module__, :code_string, ex0)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,6 +148,13 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
         m = first(methods(getfield(mod, :eval)))
         @test definition(String, m) === nothing
     end
+
+    # Related to issue [#51](https://github.com/timholy/CodeTracking.jl/issues/51)
+    # and https://github.com/JuliaDocs/Documenter.jl/issues/1779
+    ex = :(f_no_linenum(::Int) = 1)
+    deleteat!(ex.args[2].args, 1)    # delete the file & line number info
+    eval(ex)
+    @test_nowarn code_string(f_no_linenum, (Int,))
 end
 
 @testset "With Revise" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,7 +154,7 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     ex = :(f_no_linenum(::Int) = 1)
     deleteat!(ex.args[2].args, 1)    # delete the file & line number info
     eval(ex)
-    @test_nowarn code_string(f_no_linenum, (Int,))
+    @test code_string(f_no_linenum, (Int,)) === nothing
 end
 
 @testset "With Revise" begin


### PR DESCRIPTION
As suggested by @KristofferC in https://github.com/JuliaDocs/Documenter.jl/issues/1779#issuecomment-1066713491. This is related to problems using CodeTracking.jl with Documenter.jl (see https://github.com/JuliaDocs/Documenter.jl/issues/1779) or Jupyter notebooks (see https://github.com/timholy/CodeTracking.jl/issues/51). Instead of throwing an exception, `code_string` now returns `nothing` if `definition` returns `nothing`. This makes it easier to handle such a problematic case by the user.

Since the issue only appears in these on-standard environments, I do not really know a nice way to integrate an appropriate test in the current framework.