### PR TITLE
bump cov - update `ci.yml` - fix tests on local build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'  # latest LTS
           - '1'
           - 'nightly'
         os:
@@ -25,36 +25,36 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
       - name: Revise tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: julia -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); Pkg.add(PackageSpec(url="https://github.com/timholy/Revise.jl")); Pkg.test("Revise")'
+        run: |
+          julia -e '
+            using Pkg
+            Pkg.develop(path=".")
+            Pkg.add(url="https://github.com/timholy/Revise.jl")
+            Pkg.test("Revise")
+          '
       - name: Test while running Revise
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.version != '1.0' }}
-        run: TERM="xterm" julia --project -i --code-coverage -e 'using InteractiveUtils, REPL, Revise, Pkg;
-                                                                 Pkg.add("ColorTypes");
-                                                                 @async(Base.run_main_repl(true, true, false, true, false));
-                                                                 sleep(2);
-                                                                 cd("test");
-                                                                 include("runtests.jl");
-                                                                 REPL.eval_user_input(:(exit()), Base.active_repl_backend)'
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+        run: |
+          TERM="xterm" julia --project -i --code-coverage -e '
+            using InteractiveUtils, REPL, Revise, Pkg
+            Pkg.add("ColorTypes")
+            # @async(Base.run_main_repl(true, true, false, true, false))
+            sleep(2)
+            cd("test")
+            include("runtests.jl")
+            REPL.eval_user_input(:(exit()), Base.active_repl_backend)
+          '
+      - uses: julia-actions/julia-processcoverage@latest
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -117,7 +117,7 @@ function maybe_fix_path(file)
 end
 
 safe_isfile(x) = try isfile(x); catch; false end
-const BUILDBOT_STDLIB_PATH = dirname(abspath(joinpath(String((@which uuid1()).file), "..", "..", "..")))
+const BUILDBOT_STDLIB_PATH = dirname(abspath(String((@which uuid1()).file), "..", "..", ".."))
 replace_buildbot_stdlibpath(str::String) = replace(str, BUILDBOT_STDLIB_PATH => Sys.STDLIB)
 """
     path = maybe_fixup_stdlib_path(path::String)
@@ -143,33 +143,6 @@ function postpath(filename, pre)
     post = filename[first(idx) + length(pre) : end]
     post[1:1] == Base.Filesystem.path_separator && return post[2:end]
     return post
-end
-
-if Base.VERSION < v"1.1"
-    function splitpath(p::String)
-        # splitpath became available with Julia 1.1
-        # Implementation copied from Base except doesn't handle the drive
-        out = String[]
-        isempty(p) && (pushfirst!(out,p))  # "" means the current directory.
-        while !isempty(p)
-            dir, base = _splitdir_nodrive(p)
-            dir == p && (pushfirst!(out, dir); break)  # Reached root node.
-            if !isempty(base)  # Skip trailing '/' in basename
-                pushfirst!(out, base)
-            end
-            p = dir
-        end
-        return out
-    end
-    splitpath(p::AbstractString) = splitpath(String(p))
-
-    _splitdir_nodrive(path::String) = _splitdir_nodrive("", path)
-    function _splitdir_nodrive(a::String, b::String)
-        m = match(Base.Filesystem.path_dir_splitter,b)
-        m === nothing && return (a,b)
-        a = string(a, isempty(m.captures[1]) ? m.captures[2][1] : m.captures[1])
-        a, String(m.captures[3])
-    end
 end
 
 # Robust across Julia versions


### PR DESCRIPTION
- improve coverage, simplify some tests;
- update `ci.yml` (use `action@latest` where possible, and `julia-actions/cache@v1`);
- julia: drop `1.0`, min is now `1.6` LTS (`JuliaInterpreter`, `Cthulhu`, `Debugger`, `Revise` ✔: this will require bump to `1.1.0`), drop `1.0` compat code;
- remove unnecessary `joinpath` in `utils.jl` (`abspath` already joins paths);
- fix `@test occursin(Sys.STDLIB, whereis(m)[1])` on a local julia build where the source files are available locally on the fs.