### PR TITLE
Don't assume that a method body's file is always the same as the def

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -122,7 +122,7 @@ end
 function whereis(lineinfo::Core.LineInfoNode, method::Method)
     # With LineInfoNode we have certainty about whether we're in a macro expansion, but
     # we're still not guaranteed that the lineinfo points into the method otherwise
-    # (e.g. from generated or programatically defined methods)
+    # (e.g. from generated or programmatically defined methods)
     meth = lineinfo.method
     if isa(meth, WeakRef)
         meth = meth.value


### PR DESCRIPTION
`CodeTracking.whereis` currently assumes that the only thing a LineNumberNode can change is the line within the function, but that the file is always the same as the file that the method was defined in (unless there's a macro expansion). That is true for methods that come from the parser, but not necessarily for those that were generated programatically, causing `whereis` to return an incorrect file with the correct line number, causing dowstream issues like https://github.com/JuliaDebug/CassetteOverlay.jl/issues/18.