### PR TITLE
Add invalidation-insulating accessors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CodeTracking"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.1.2"
+version = "1.2.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
Because IdDict's `setindex!` uses `@nospecialize` on both the key and
value, it makes callers vulnerable to invalidation. These convenience
utilities allow callers to insulate themselves from invalidation.
These will be used by Revise.