### PR TITLE
Handle method defs that end in a semicolon

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -235,7 +235,7 @@ function definition(::Type{String}, method::Method)
     iend = prevind(src, iend)
     if isfuncexpr(ex, method.name)
         iend = min(iend, lastindex(src))
-        return strip(src[istart:iend], '\n'), line
+        return clean_source(src[istart:iend]), line
     end
     # The function declaration was presumably on a previous line
     lineindex = lastindex(linestarts)
@@ -250,7 +250,15 @@ function definition(::Type{String}, method::Method)
         line -= 1
     end
     lineindex <= linestop && return nothing
-    return chomp(src[istart:iend-1]), line
+    return clean_source(src[istart:iend-1]), line
+end
+
+function clean_source(src)
+    src = strip(src, '\n')
+    if endswith(src, ';')
+        src = src[1:prevind(src, end)]
+    end
+    return src
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,6 +28,9 @@ checkname(fname::QuoteNode, name) = checkname(fname.value, name)
 
 function isfuncexpr(ex, name=nothing)
     # Strip any macros that wrap the method definition
+    if ex isa Expr && ex.head === :toplevel
+        ex = ex.args[end]
+    end
     while ex isa Expr && ex.head === :macrocall && length(ex.args) >= 3
         ex = ex.args[end]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,6 +104,9 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     @test whereis(m) == ("REPL[1]", 1)
     CodeTracking.method_lookup_callback[] = oldlookup
 
+    # Method definitions ending in semicolon
+    @test code_string(has_semicolon1, (Int, Int)) == "has_semicolon1(x, y) = x + y"
+
     # Test implicit replacement of `BUILDBOT_STDLIB_PATH`
     m = first(methods(Test.eval))
     @test isfile(whereis(m)[1])
@@ -228,6 +231,15 @@ end
             m = first(methods(f))
             @test definition(String, first(methods(f))) == (fstr, 1)
             @test !isempty(signatures_at(String(m.file), m.line))
+
+            histidx += 1
+            fstr = "has_semicolon2(x, y) = x + y;"
+            ex = Base.parse_input_line(fstr; filename="REPL[$histidx]")
+            f = Core.eval(Main, ex)
+            push!(hp.history, fstr)
+            @test code_string(has_semicolon2, (Int, Int)) == "has_semicolon2(x, y) = x + y"
+
+            pop!(hp.history)
             pop!(hp.history)
         elseif haskey(ENV, "CI")
             error("CI Revise tests must be run with -i")

--- a/test/script.jl
+++ b/test/script.jl
@@ -66,3 +66,5 @@ if isdefined(Base, Symbol("@assume_effects"))
         end
     end
 end
+
+has_semicolon1(x, y) = x + y;


### PR DESCRIPTION
These get an extra `:toplevel` Expr wrapper, which we need to strip.