### PR TITLE
Also match argnames to validate methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CodeTracking"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.2.2"
+version = "1.3.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/README.md
+++ b/README.md
@@ -143,3 +143,8 @@ file/line info in the method itself if Revise isn't running.)
 
 CodeTracking is perhaps best thought of as the "query" part of Revise.jl,
 providing a lightweight and stable API for gaining access to information it maintains internally.
+
+## Limitations (without Revise)
+
+- parsing sometimes starts on the wrong line. Line numbers are determined by counting `'\n'` in the source file, without parsing the contents. Consequently quoted- or in-code `'\n'` can mess up CodeTracking's notion of line numbering
+- default constructor methods for `struct`s are not found

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -268,7 +268,7 @@ function definition(::Type{String}, method::Method)
         line -= 1
     end
     lineindex <= linestop && return nothing
-    return clean_source(src[istart:iend-1]), line
+    return clean_source(src[istart:prevind(src, iend)]), line
 end
 
 function clean_source(src)

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -254,11 +254,8 @@ function definition(::Type{String}, method::Method)
     # Parse the function definition (hoping that we've found the right location to start)
     ex, iend = Meta.parse(src, istart; raise=false)
     iend = prevind(src, iend)
-    if is_func_expr(ex, method)
-        iend = min(iend, lastindex(src))
-        return clean_source(src[istart:iend]), line
-    end
-    # The function declaration was presumably on a previous line
+    # The function declaration may have been on a previous line,
+    # allow some slop
     lineindex = lastindex(linestarts)
     linestop = max(0, lineindex - 20)
     while !is_func_expr(ex, method) && lineindex > linestop

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -251,9 +251,9 @@ function definition(::Type{String}, method::Method)
         push!(linestarts, istart)
         istart = findnext(eol, src, istart) + 1
     end
+    push!(linestarts, length(src) + 1)
     # Parse the function definition (hoping that we've found the right location to start)
     ex, iend = Meta.parse(src, istart; raise=false)
-    iend = prevind(src, iend)
     # The function declaration may have been on a previous line,
     # allow some slop
     lineindex = lastindex(linestarts)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -209,7 +209,11 @@ end
 
 function kwmethod_basename(meth::Method)
     name = meth.name
-    mtch = match(r"^#+(.*)#", string(name))
+    sname = string(name)
+    mtch = match(r"^(.*)##kw$", sname)
+    if mtch === nothing
+        mtch = match(r"^#+(.*)#", sname)
+    end
     name = mtch === nothing ? name : Symbol(only(mtch.captures))
     ftypname = Symbol(string('#', name))
     idx = findfirst(Base.unwrap_unionall(meth.sig).parameters) do @nospecialize(T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,7 +28,7 @@ end
 function get_func_expr(@nospecialize(ex))
     isa(ex, Expr) || return ex
     # Strip any macros that wrap the method definition
-    while isa(ex, Expr) && ex.head ∈ (:toplevel, :macrocall)
+    while isa(ex, Expr) && ex.head ∈ (:toplevel, :macrocall, :global, :local)
         ex.head == :macrocall && length(ex.args) < 3 && return ex
         ex = ex.args[end]
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -102,6 +102,7 @@ function is_func_expr(@nospecialize(ex), meth::Method)
     end
     for (arg, marg) in zip(exargs, margs[2:end])
         aname = get_argname(arg)
+        aname === :_ && continue
         aname === marg || (aname === Symbol("#unused#") && marg === Symbol("")) || return false
     end
     return true  # this will match any fcn `() -> ...`, but file/line is the only thing we have

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,7 +58,6 @@ function is_func_expr(@nospecialize(ex), name::Symbol)
 end
 
 function is_func_expr(@nospecialize(ex), meth::Method)
-    @show ex
     ex = get_func_expr(ex)
     is_func_expr(ex) || return false
     if ex.head == :(->)
@@ -96,7 +95,6 @@ function is_func_expr(@nospecialize(ex), meth::Method)
         popfirst!(exargs)   # don't match kwargs
     end
     margs = Base.method_argnames(meth)
-    @show exargs margs
     if is_kw_call(meth)
         margs = margs[findlast(==(Symbol("")), margs)+1:end]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -213,6 +213,12 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     @test occursin("::Nowhere", src)
     @test line == 108
 
+    # global annotations
+    m = which(inlet, (Any,))
+    src, line = definition(String, m)
+    @test occursin("inlet(x)", src)
+    @test line == 112
+
     # Invalidation-insulating methods used by Revise and perhaps others
     d = IdDict{Union{String,Symbol},Union{Function,Vector{Function}}}()
     CodeTracking.invoked_setindex!(d, sin, "sin")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,14 +136,12 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
 
     # Issues raised in #48
     m = @which(sum([1]; dims=1))
+    def = definition(String, m)
+    @test isa(def[1], AbstractString)
     if !isdefined(Main, :Revise)
-        def = definition(String, m)
-        @test def === nothing || isa(def[1], AbstractString)
         def = definition(Expr, m)
         @test def === nothing || isa(def, Expr)
     else
-        def = definition(String, m)
-        @test isa(def[1], AbstractString)
         def = definition(Expr, m)
         @test isa(def, Expr)
     end
@@ -178,14 +176,30 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     src, line = definition(String, m)
     @test occursin("x^3", src)
     @test line == 52
+    m = only(methods(f80_2))
+    src, line = definition(String, m)
+    @test occursin("x*y", src)
+    @test line == 53
 
     # Issue #103
     if isdefined(Base, Symbol("@assume_effects"))
         m = only(methods(pow103))
         src, line = definition(String, m)
         @test occursin("res *= x", src)
-        @test line == 57
+        @test line == 58
     end
+
+    # @eval-ed methods
+    m = which(mysin, (Real,))
+    src, line = definition(String, m)
+    @test occursin("xf", src)
+    @test line == 85
+
+    # unnamed arguments
+    m = which(unnamedarg, (Type{String}, Any))
+    src, line = definition(String, m)
+    @test occursin("string(x)", src)
+    @test line == 93
 
     # Invalidation-insulating methods used by Revise and perhaps others
     d = IdDict{Union{String,Symbol},Union{Function,Vector{Function}}}()
@@ -282,15 +296,9 @@ end
 end
 
 @testset "kwargs methods" begin
-    m = nothing
-    for i in 1:30
-        s = Symbol("#func_2nd_kwarg#$i")
-        if isdefined(Main, s)
-            m = @eval $s
-        end
-    end
-    m === nothing && error("couldn't find keyword function")
-    body, loc = CodeTracking.definition(String, first(methods(m)))
+    mdirect = only(methods(func_2nd_kwarg))
+    fbody = Base.bodyfunction(mdirect)
+    body, loc = CodeTracking.definition(String, first(methods(fbody)))
     @test loc == 28
     @test body == "func_2nd_kwarg(; kw=2) = true"
 end
@@ -319,7 +327,6 @@ struct Functor end
     @test body == "(::Functor)(x, y) = x+y"
 end
 
-if v"1.6" <= VERSION
 @testset "kwfuncs" begin
     body, _ = CodeTracking.definition(String, @which fkw(; x=1))
     @test body == """
@@ -327,4 +334,27 @@ if v"1.6" <= VERSION
         x
     end"""
 end
+
+@testset "Decorated args" begin
+    body, _ = CodeTracking.definition(String, which(nospec, (Any,)))
+    @test body == "nospec(@nospecialize(x)) = 2x"
+    body, _ = CodeTracking.definition(String, which(nospec2, (Vector,)))
+    @test body == "nospec2(@nospecialize(x::AbstractVecOrMat)) = first(x)"
+    body, _ = CodeTracking.definition(String, which(nospec3, (Symbol,)))
+    @test body == "nospec3(name::Symbol, @nospecialize(arg=nothing)) = name"
+    body, _ = CodeTracking.definition(String, which(nospec3, (Symbol, String)))
+    @test body == "nospec3(name::Symbol, @nospecialize(arg=nothing)) = name"
+    body, _ = CodeTracking.definition(String, which(withva, (Char,)))
+    @test body == "withva(a...) = length(a)"
+    body, _ = CodeTracking.definition(String, which(hasdefault, (Int,)))
+    @test body == "hasdefault(xd, yd=2) = xd + yd"
+    body, _ = CodeTracking.definition(String, which(hasdefault, (Int, Float32)))
+    @test body == "hasdefault(xd, yd=2) = xd + yd"
+    body, _ = CodeTracking.definition(String, which(hasdefaulttypearg, (Type{Float32},)))
+    @test body == "hasdefaulttypearg(::Type{T}=Rational{Int}) where T = zero(T)"
+end
+
+@testset "tuple-destructured args" begin
+    body, _ = CodeTracking.definition(String, which(diffminmax, (Any,)))
+    @test body == "diffminmax((min, max)) = max - min"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -300,7 +300,7 @@ end
     fbody = Base.bodyfunction(mdirect)
     body, loc = CodeTracking.definition(String, first(methods(fbody)))
     @test loc == 28
-    @test body == "func_2nd_kwarg(; kw=2) = true"
+    @test body == "func_2nd_kwarg(a, b; kw=2) = true"
 end
 
 @testset "method extensions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,7 +286,7 @@ end
             end
             push!(hp.history, fstr)
             m = first(methods(f))
-            @test definition(String, first(methods(f))) == (fstr, 1)
+            @test definition(String, m) == (fstr, 1)
             @test !isempty(signatures_at(String(m.file), m.line))
 
             histidx += 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,6 +208,10 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     src, line = definition(String, m)
     @test occursin("string(x)", src)
     @test line == 93
+    m = which(mypush!, (Nowhere, Any))
+    src, line = definition(String, m)
+    @test occursin("::Nowhere", src)
+    @test line == 108
 
     # Invalidation-insulating methods used by Revise and perhaps others
     d = IdDict{Union{String,Symbol},Union{Function,Vector{Function}}}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,6 +219,24 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     @test occursin("inlet(x)", src)
     @test line == 112
 
+    # Callables
+    gg = Gaussian(1.0)
+    m = @which gg(2)
+    src, line = definition(String, m)
+    @test occursin("::Gaussian)(x)", src)
+    @test line == 119
+    invt = Invert()
+    m = @which invt([false, true])
+    src, line = definition(String, m)
+    @test occursin("::Invert)(v", src)
+    @test line == 121
+
+    # Constructor with `where`
+    m = @which Invert((false, true))
+    src, line = definition(String, m)
+    @test occursin("(::Type{T})(itr) where {T<:Invert}", src)
+    @test line == 122
+
     # Invalidation-insulating methods used by Revise and perhaps others
     d = IdDict{Union{String,Symbol},Union{Function,Vector{Function}}}()
     CodeTracking.invoked_setindex!(d, sin, "sin")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,6 +194,14 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     src, line = definition(String, m)
     @test occursin("xf", src)
     @test line == 85
+    m = only(methods(Base.bodyfunction(m)))
+    src, line = definition(String, m)
+    @test occursin("xf", src)
+    @test line == 85
+    m = @which mysin(0.5; return_zero=true)
+    src, line = definition(String, m)
+    @test occursin("xf", src)
+    @test line == 85
 
     # unnamed arguments
     m = which(unnamedarg, (Type{String}, Any))

--- a/test/script.jl
+++ b/test/script.jl
@@ -80,7 +80,7 @@ LikeNamedTuple{names}(args::Tuple) where {names} = LikeNamedTuple{names,typeof(a
 
 # Test @eval-ed methods
 # This is taken from the definition of `sin(::Int)` in Base, copied here for testing purposes
-# in case the implementation changes. Also added a kw.
+# in case the implementation changes. Also added a (useless) kw.
 for f in (:mysin,)
     @eval function ($f)(x::Real; return_zero::Bool=false)
         xf = float(x)
@@ -90,7 +90,7 @@ for f in (:mysin,)
 end
 mysin(x::AbstractFloat) = sin(x)
 
-unnamedarg(::Type{String}, x) = string(x)
+unnamedarg(::Type{String}, x) = string(x)   # see more unnamed on line 108
 
 # "decorated" args
 nospec(@nospecialize(x)) = 2x
@@ -102,3 +102,7 @@ hasdefaulttypearg(::Type{T}=Rational{Int}) where T = zero(T)
 
 # tuple-destructuring
 diffminmax((min, max)) = max - min
+
+# _ args
+struct Nowhere end
+mypush!(::Nowhere, _) = nothing

--- a/test/script.jl
+++ b/test/script.jl
@@ -106,3 +106,8 @@ diffminmax((min, max)) = max - min
 # _ args
 struct Nowhere end
 mypush!(::Nowhere, _) = nothing
+
+# global
+let
+    global inlet(x) = x^2
+end

--- a/test/script.jl
+++ b/test/script.jl
@@ -111,3 +111,12 @@ mypush!(::Nowhere, _) = nothing
 let
     global inlet(x) = x^2
 end
+
+# Callables
+struct Gaussian
+    σ::Float64
+end
+(g::Gaussian)(x) = exp(-x^2 / (2*g.σ^2)) / (sqrt(2*π)*g.σ)
+struct Invert end
+(::Invert)(v::AbstractVector{Bool}) = (!).(v)
+(::Type{T})(itr) where {T<:Invert} = [!x for x in itr]

--- a/test/script.jl
+++ b/test/script.jl
@@ -80,9 +80,9 @@ LikeNamedTuple{names}(args::Tuple) where {names} = LikeNamedTuple{names,typeof(a
 
 # Test @eval-ed methods
 # This is taken from the definition of `sin(::Int)` in Base, copied here for testing purposes
-# in case the implementation changes
+# in case the implementation changes. Also added a kw.
 for f in (:mysin,)
-    @eval function ($f)(x::Real)
+    @eval function ($f)(x::Real; return_zero::Bool=false)
         xf = float(x)
         x === xf && throw(MethodError($f, (x,)))
         return ($f)(xf)

--- a/test/script.jl
+++ b/test/script.jl
@@ -25,7 +25,7 @@ function f50()   # issue #50
 end
 
 func_1st_nokwarg() = true
-func_2nd_kwarg(; kw=2) = true
+func_2nd_kwarg(a, b; kw=2) = true
 
 module Foo
 module Bar

--- a/test/script.jl
+++ b/test/script.jl
@@ -50,6 +50,7 @@ end
 
 # Issue #80
 f80 = x -> 2 * x^3 + 1
+f80_2 = (x, y) -> x*y
 
 # Issue #103
 if isdefined(Base, Symbol("@assume_effects"))
@@ -76,3 +77,28 @@ end
 LikeNamedTuple() = LikeNamedTuple{(),Tuple{}}(())
 
 LikeNamedTuple{names}(args::Tuple) where {names} = LikeNamedTuple{names,typeof(args)}(args)
+
+# Test @eval-ed methods
+# This is taken from the definition of `sin(::Int)` in Base, copied here for testing purposes
+# in case the implementation changes
+for f in (:mysin,)
+    @eval function ($f)(x::Real)
+        xf = float(x)
+        x === xf && throw(MethodError($f, (x,)))
+        return ($f)(xf)
+    end
+end
+mysin(x::AbstractFloat) = sin(x)
+
+unnamedarg(::Type{String}, x) = string(x)
+
+# "decorated" args
+nospec(@nospecialize(x)) = 2x
+nospec2(@nospecialize(x::AbstractVecOrMat)) = first(x)
+nospec3(name::Symbol, @nospecialize(arg=nothing)) = name
+withva(a...) = length(a)
+hasdefault(xd, yd=2) = xd + yd
+hasdefaulttypearg(::Type{T}=Rational{Int}) where T = zero(T)
+
+# tuple-destructuring
+diffminmax((min, max)) = max - min


### PR DESCRIPTION
While working on TypedSyntax.jl it became apparent that CodeTracking
sometimes returns spurious results. At least some of these arise from
the recent support of anonymous functions, #102, which might in
retrospect have been ill-considered. Rather than back that change
out, this adopts a different resolution: validate the hits more
carefully.  The primary mechanism introduced here is to match not just
the function name, but also the argument names. This can work even for
anonymous functions, so we do not need to drop support for them.

This also adds quite a few new tests. These additions would have
passed before, but they proved valuable to ensure that the new
argname-matching works sufficiently well.

On TypedSyntax's "exhaustive.jl" test, this brings the
number of failed cases (specifically, the `badmis`) from
either 460 or 94 (depending on whether you include a few fixes
in TypedSyntax) to just 2.

TODO:
- [x] search JuliaHub to see if any of the deleted code is used by other packages (see suggestion below)
- [x] analyze the `missingmethod` output of TypedSyntax's `exhaustive.jl` test and see if this is missing some "real" methods (the risk is that greater finickyness may be excluding some actual methods)
- [x] check whether JuliaInterpreter, Debugger, and Revise pass with this PR
- [x] (most important): decide if this package should only return "usable" methods or whether "it's in here somewhere" is the behavior we'd want (see below, https://github.com/timholy/CodeTracking.jl/pull/108#issuecomment-1475800301).