### PR TITLE
Also handle splats in interpolated args

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -118,7 +118,13 @@ function is_func_expr(@nospecialize(ex), meth::Method)
         margs = margs[idx:end]
     end
     for (arg, marg) in zip(exargs, margs[2:end])
-        isexpr(arg, :$) && continue
+        if isexpr(arg, :$)
+            # If this is a splat, we may not even have the right number of args. In that case,
+            # just trust the matching we've done so far.
+            lastarg = arg.args[end]
+            isexpr(lastarg, :...) && return true
+            continue
+        end
         aname = get_argname(arg)
         aname === :_ && continue
         aname === marg || (aname === Symbol("#unused#") && marg === Symbol("")) || return false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,40 +206,45 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     src, line = definition(String, m)
     @test occursin("atan(y, x)", src)
     @test line == 93
+    m = which(hasthreeargs, (Real, Real, Bool))
+    src, line = definition(String, m)
+    @test occursin("x + y + z", src)
+    @test line == 94
+
 
     # unnamed arguments
     m = which(unnamedarg, (Type{String}, Any))
     src, line = definition(String, m)
     @test occursin("string(x)", src)
-    @test line == 98
+    @test line == 97
     m = which(mypush!, (Nowhere, Any))
     src, line = definition(String, m)
     @test occursin("::Nowhere", src)
-    @test line == 113
+    @test line == 112
 
     # global annotations
     m = which(inlet, (Any,))
     src, line = definition(String, m)
     @test occursin("inlet(x)", src)
-    @test line == 117
+    @test line == 116
 
     # Callables
     gg = Gaussian(1.0)
     m = @which gg(2)
     src, line = definition(String, m)
     @test occursin("::Gaussian)(x)", src)
-    @test line == 124
+    @test line == 123
     invt = Invert()
     m = @which invt([false, true])
     src, line = definition(String, m)
     @test occursin("::Invert)(v", src)
-    @test line == 126
+    @test line == 125
 
     # Constructor with `where`
     m = @which Invert((false, true))
     src, line = definition(String, m)
     @test occursin("(::Type{T})(itr) where {T<:Invert}", src)
-    @test line == 127
+    @test line == 126
 
     # Invalidation-insulating methods used by Revise and perhaps others
     d = IdDict{Union{String,Symbol},Union{Function,Vector{Function}}}()

--- a/test/script.jl
+++ b/test/script.jl
@@ -90,9 +90,8 @@ for f in (:mysin,)
 end
 mysin(x::AbstractFloat) = sin(x)
 let args = [:(y::Real), :(x::Real)]
-    @eval function dollaratan($(args...))
-        return atan(y, x)
-    end
+    @eval dollaratan($(args...)) = atan(y, x)
+    @eval hasthreeargs($(args...), z::Bool) = x + y + z
 end
 
 unnamedarg(::Type{String}, x) = string(x)   # see more unnamed on line 108


### PR DESCRIPTION
If an arg is interpolated and has a splat, we can't be sure that
arguments will be aligned anymore. Terminate the validation.

Improves #110 and the fix for
https://github.com/JuliaDebug/Cthulhu.jl/issues/425