### PR TITLE
Eliminate piracy of `convert(LineNumberNode, ::LineInfoNode)`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -168,9 +168,6 @@ end
 fileline(lin::LineInfoNode)   = String(lin.file), lin.line
 fileline(lnn::LineNumberNode) = String(lnn.file), lnn.line
 
-# This is piracy, but it's not ambiguous in terms of what it should do
-Base.convert(::Type{LineNumberNode}, lin::LineInfoNode) = LineNumberNode(lin.line, lin.file)
-
 # This regex matches the pseudo-file name of a REPL history entry.
 const rREPL = r"^REPL\[(\d+)\]$"
 # Match anonymous function names


### PR DESCRIPTION
Closes #113