### PR TITLE
Fix lookup for methods defined inline with eval

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -259,6 +259,12 @@ function definition(::Type{String}, method::Method)
     lineindex = lastindex(linestarts)
     linestop = max(0, lineindex - 20)
     while !is_func_expr(ex, method) && lineindex > linestop
+        if ex.head == :call && length(ex.args) > 1 && first(ex.args) == :eval && last(ex.args).head == :quote && length(last(ex.args).args) > 0
+            actual_ex = first(last(ex.args).args)
+            if is_func_expr(actual_ex, method)
+                return clean_source(string(actual_ex)), line
+            end
+        end
         istart = linestarts[lineindex]
         try
             ex, iend = Meta.parse(src, istart)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,6 +250,12 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     d = IdDict{Union{String,Symbol},Union{Function,Vector{Function}}}()
     CodeTracking.invoked_setindex!(d, sin, "sin")
     @test CodeTracking.invoked_get!(Vector{Function}, d, :cos) isa Vector{Function}
+
+    # Issue 115, Cthulhu issue 474
+    m = @which NamedTuple{(),Tuple{}}(())
+    src, line = definition(String, m)
+    @test occursin("NamedTuple{names, T}(args::T) where {names, T <: Tuple}", src)
+    @test line == m.line
 end
 
 @testset "With Revise" begin


### PR DESCRIPTION
This fixes the `NamedTuple` example in #115, the problem was that the definition,
```jl
eval(Core, :(NamedTuple{names,T}(args::T) where {names, T <: Tuple} =
             $(Expr(:splatnew, :(NamedTuple{names,T}), :args))))
```
has the beginning of the function definition on the same line as the `eval`.