### PR TITLE
Fix `Array` example in #115

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -91,6 +91,10 @@ function is_func_expr(@nospecialize(ex), meth::Method)
                 fname = fname.args[end]
                 modified = true
             end
+            if isexpr(fname, :where)
+                fname = fname.args[1]
+                modified = true
+            end
         end
         if !(isa(fname, Symbol) && is_gensym(fname)) && !isexpr(fname, :$)
             if fname === :Type && isexpr(ex.args[1], :where) && isexpr(callex.args[1], :(::)) && isexpr(callex.args[1].args[end], :curly)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,6 +250,12 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     d = IdDict{Union{String,Symbol},Union{Function,Vector{Function}}}()
     CodeTracking.invoked_setindex!(d, sin, "sin")
     @test CodeTracking.invoked_get!(Vector{Function}, d, :cos) isa Vector{Function}
+
+    # Issue 115, Cthulhu issue 404
+    m = @which (Vector)(Int[])
+    src, line = definition(String, m)
+    @test occursin("(Array{T,N} where T)(x::AbstractArray{S,N}) where {S,N}", src)
+    @test line == m.line
 end
 
 @testset "With Revise" begin


### PR DESCRIPTION
The problem here was that `strip_gensym(meth.name) = Array` but `fname = (Array{T, N} where T)`, so I added some code to match on the `where` to simplify `fname`.