### PR TITLE
Check for unexpected EOF in `definition`

### DIFF
--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -249,7 +249,9 @@ function definition(::Type{String}, method::Method)
     istart = 1
     for _ = 1:line-1
         push!(linestarts, istart)
-        istart = findnext(eol, src, istart) + 1
+        istart = findnext(eol, src, istart)
+        istart === nothing && return nothing   # unexpected EOF
+        istart += 1
     end
     push!(linestarts, istart)
     # Parse the function definition (hoping that we've found the right location to start)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -268,6 +268,9 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     # Parsed result gives a symbol instead of expression
     m = @which symbol_function(1)
     @test_nowarn definition(String, m)
+
+    # #124
+    @test definition(String, only(methods(wrongline))) === nothing
 end
 
 @testset "With Revise" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -270,7 +270,9 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
     @test_nowarn definition(String, m)
 
     # #124
-    @test definition(String, only(methods(wrongline))) === nothing
+    if !isdefined(Main, :Revise)
+        @test definition(String, only(methods(wrongline))) === nothing
+    end
 end
 
 @testset "With Revise" begin

--- a/test/script.jl
+++ b/test/script.jl
@@ -139,3 +139,6 @@ let argnames = :args
         end
     end)
 end
+
+wrongline() = 1    # for use testing #124
+only(methods(wrongline)).line = 9999   # unclear how it happened in the wild, but this at least catches the problem


### PR DESCRIPTION
It would be nice to have a more realistic reproducer, but hopefully this suffices.

Fixes #124
