### PR TITLE
Fix tests for inverted linetable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,13 @@ jobs:
           TERM="xterm" julia --project -i --code-coverage -e '
             using InteractiveUtils, REPL, Revise, Pkg
             Pkg.add("ColorTypes")
-            @async(Base.run_main_repl(true, true, false, true, false))
-            sleep(2)
+            t = @async(
+              VERSION >= v"1.12.0-DEV.612" ? Base.run_main_repl(true, true, :no, true) :
+              VERSION >= v"1.11.0-DEV.222" ? Base.run_main_repl(true, true, :no, true, false)   :
+                                            Base.run_main_repl(true, true, false, true, false))
+            isdefined(Base, :errormonitor) && Base.errormonitor(t)
+            while (!isdefined(Base, :active_repl_backend) || isnothing(Base.active_repl_backend)) sleep(0.1) end
+            pushfirst!(Base.active_repl_backend.ast_transforms, Revise.revise_first)
             cd("test")
             include("runtests.jl")
             if Base.VERSION.major == 1 && Base.VERSION.minor >= 9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           julia -e '
             using Pkg
             Pkg.develop(path=".")
-            Pkg.add(url="https://github.com/timholy/Revise.jl")
+            Pkg.add("Revise")
             Pkg.test("Revise")
           '
       - name: Test while running Revise

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -98,7 +98,7 @@ Otherwise `loc` will be `(filepath, line)`.
 """
 function whereis(sf::StackTraces.StackFrame)
     sf.linfo === nothing && return nothing
-    return whereis(sf, sf.linfo.def)
+    return whereis(sf, getmethod(sf.linfo))
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -210,6 +210,21 @@ else
         return [iszero(cl[pc]) ? Core.LineInfoNode[] : [lt[cl[pc]]] for pc = eachindex(cl)]
     end
 end
+@doc """
+    scopes = linetable_scopes(m::Method)
+
+Return an array of "scopes" for each statement in the lowered code for `m`.
+If `src = Base.uncompressed_ast(m)`, then `scopes[pc]` is an vector of `LineInfoNode`
+objects that represent the scopes active at the statement at position `pc` in `src.code`.
+
+On Julia 1.12 and later, `scopes[pc]` may have length larger than 1, where the first entry
+is for the source location in `m`, and any later entries reflect code from inlining.
+It will be a vector of `Base.Compiler.IRShow.LineInfoNode` objects.
+
+Prior to Julia 1.12, `scopes[pc]` will have length 1, and will be a vector of `Core.LineInfoNode`
+objects (which have more fields than `Base.Compiler.IRShow.LineInfoNode`). It will represent
+the final stage of inlining for the statement at position `pc` in `src.code`.
+""" linetable_scopes
 
 getmethod(m::Method) = m
 getmethod(mi::Core.MethodInstance) = getmethod(mi.def)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,13 +129,13 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
         @info "hello"
     end
     m = first(methods(f150))
-    src = Base.uncompressed_ast(m)
-    idx = findfirst(lin -> String(lin.file) == @__FILE__, src.linetable)
-    lin = src.linetable[idx]
+    scopes = CodeTracking.linetable_scopes(m)
+    idx = findfirst(sc -> all(lin -> String(lin.file) == @__FILE__, sc), scopes)
+    lin = first(scopes[idx])
     file, line = whereis(lin, m)
     @test endswith(file, String(lin.file))
-    idx = findfirst(lin -> String(lin.file) != @__FILE__, src.linetable)
-    lin = src.linetable[idx]
+    idx = findfirst(sc -> !all(lin -> String(lin.file) == @__FILE__, sc), scopes)
+    lin = first(scopes[idx])
     file, line = whereis(lin, m)
     if !Sys.iswindows()
         @test endswith(file, String(lin.file))


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/52415 introduced a fundamental
change in how line information is encoded. Because this package delves
into internals, there were a couple tests that failed on Julia 1.12+.
This adds a utility, `CodeTracking.linetable_scopes`, that makes it
easier to work with the new representation across Julia versions.

This may be useful in fixing some JuliaInterpreter issues.

CC @aviatesk, @vtjnash
