### PR TITLE
Add method table as key for `method_info`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
           julia -e '
             using Pkg
             Pkg.develop(path=".")
-            Pkg.add("Revise")
+            pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables https://github.com/serenity4/Revise.jl#revise-external-methodtables"
+            # Pkg.add("Revise")
             Pkg.test("Revise")
           '
       - name: Test while running Revise

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'  # latest LTS
+          - 'lts'
           - '1'
           - 'pre'
           - 'nightly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,7 @@ jobs:
           julia -e '
             using Pkg
             Pkg.develop(path=".")
-            pkg"add https://github.com/serenity4/JuliaInterpreter.jl#codetracking-v2 https://github.com/serenity4/LoweredCodeUtils.jl#support-external-methodtables https://github.com/serenity4/Revise.jl#revise-external-methodtables"
-            # Pkg.add("Revise")
+            Pkg.add("Revise")
             Pkg.test("Revise")
           '
       - name: Test while running Revise

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CodeTracking"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.3.9"
+version = "2.0.0-DEV"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/README.md
+++ b/README.md
@@ -116,13 +116,15 @@ You can also find the method-signatures at a particular location:
 
 ```julia
 julia> signatures_at(ColorTypes, "src/traits.jl", 14)
-1-element Array{Any,1}:
- Tuple{typeof(red),AbstractRGB}
+1-element Vector{Pair{Union{Nothing, Core.MethodTable}, Type}}:
+ nothing => Tuple{typeof(red),AbstractRGB}
 
 julia> signatures_at("/home/tim/.julia/packages/ColorTypes/BsAWO/src/traits.jl", 14)
-1-element Array{Any,1}:
- Tuple{typeof(red),AbstractRGB}
+1-element Vector{Pair{Union{Nothing, Core.MethodTable}, Type}}:
+ nothing => Tuple{typeof(red),AbstractRGB}
 ```
+
+with the first element being the method table for which the method has been defined (a value of `nothing` denotes the default method table).
 
 CodeTracking also helps correcting for [Julia issue #26314](https://github.com/JuliaLang/julia/issues/26314):
 

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -33,8 +33,8 @@ include("utils.jl")
 #   - `missing`, to indicate that the method cannot be located
 #   - a list of `(lnn,ex)` pairs. In almost all cases there will be just one of these,
 #     but "mistakes" in moving methods from one file to another can result in more than
-#     definition. The last pair in the list is the currently-active definition.
-const method_info = IdDict{Pair{<:Union{Nothing, MethodTable}, <:Type},Union{Missing,Vector{Tuple{LineNumberNode,Expr}}}}()
+#     one definition. The last pair in the list is the currently-active definition.
+const method_info = IdDict{Pair{Union{Nothing, MethodTable}, Type},Union{Missing,Vector{Tuple{LineNumberNode,Expr}}}}()
 
 const _pkgfiles = Dict{PkgId,PkgFiles}()
 
@@ -59,7 +59,7 @@ const juliabase = joinpath("julia", "base")
 const juliastdlib = joinpath("julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)")
 
 method_table(method::Method) = isdefined(method, :external_mt) ? method.external_mt::MethodTable : nothing
-method_info_key(method::Method) = method_table(method) => method.sig
+method_info_key(method::Method) = Pair{Union{Nothing, MethodTable}, Type}(method_table(method), method.sig)
 
 ### Public API
 

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -61,8 +61,7 @@ const expressions_callback = Ref{Any}(nothing)
 const juliabase = joinpath("julia", "base")
 const juliastdlib = joinpath("julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)")
 
-method_table(method::Method) = isdefined(method, :external_mt) ? method.external_mt::MethodTable : nothing
-MethodInfoKey(method::Method) = MethodInfoKey(method_table(method), method.sig)
+MethodInfoKey(method::Method) = MethodInfoKey(Base.get_methodtable(method), method.sig)
 
 ### Public API
 

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -61,7 +61,8 @@ const expressions_callback = Ref{Any}(nothing)
 const juliabase = joinpath("julia", "base")
 const juliastdlib = joinpath("julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)")
 
-MethodInfoKey(method::Method) = MethodInfoKey(Base.get_methodtable(method), method.sig)
+method_table(method::Method) = isdefined(method, :external_mt) ? method.external_mt::MethodTable : nothing
+MethodInfoKey(method::Method) = MethodInfoKey(method_table(method), method.sig)
 
 ### Public API
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -400,5 +400,5 @@ getpkgid(uuid::UUID, libname) = PkgId(uuid, libname)
 # callers vulnerable to invalidation. These convenience utilities allow callers to insulate
 # themselves from invalidation. These are used by Revise.
 # example package triggering invalidation: StaticArrays (new `convert(Type{Array{T,N}}, ::AbstractArray)` methods)
-invoked_setindex!(dct::IdDict{K,V}, @nospecialize(val), @nospecialize(key)) where {K,V} = Base.invokelatest(setindex!, dct, val, key)::typeof(dct)
-invoked_get!(::Type{T}, dct::IdDict{K,V}, @nospecialize(key)) where {K,V,T<:V} = Base.invokelatest(get!, T, dct, key)::V
+invoked_setindex!(dct::IdDict{K,V}, @nospecialize(val), @nospecialize(key)) where {K,V} = Base.invokelatest(setindex!, dct, val, convert(K, key))::typeof(dct)
+invoked_get!(::Type{T}, dct::IdDict{K,V}, @nospecialize(key)) where {K,V,T<:V} = Base.invokelatest(get!, T, dct, convert(K, key))::V

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -400,5 +400,5 @@ getpkgid(uuid::UUID, libname) = PkgId(uuid, libname)
 # callers vulnerable to invalidation. These convenience utilities allow callers to insulate
 # themselves from invalidation. These are used by Revise.
 # example package triggering invalidation: StaticArrays (new `convert(Type{Array{T,N}}, ::AbstractArray)` methods)
-invoked_setindex!(dct::IdDict{K,V}, @nospecialize(val), @nospecialize(key)) where {K,V} = Base.invokelatest(setindex!, dct, val, convert(K, key))::typeof(dct)
-invoked_get!(::Type{T}, dct::IdDict{K,V}, @nospecialize(key)) where {K,V,T<:V} = Base.invokelatest(get!, T, dct, convert(K, key))::V
+invoked_setindex!(dct::IdDict{K,V}, @nospecialize(val), @nospecialize(key)) where {K,V} = Base.invokelatest(setindex!, dct, val, key)::typeof(dct)
+invoked_get!(::Type{T}, dct::IdDict{K,V}, @nospecialize(key)) where {K,V,T<:V} = Base.invokelatest(get!, T, dct, key)::V

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,7 +101,7 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
 
     # Test a method marked as missing
     m = @which sum(1:5)
-    CodeTracking.method_info[nothing => m.sig] = missing
+    CodeTracking.invoked_setindex!(CodeTracking.method_info, missing, nothing => m.sig)
     @test whereis(m) == (CodeTracking.maybe_fix_path(String(m.file)), m.line)
     @test definition(m) === nothing
 
@@ -466,7 +466,7 @@ if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :(var"@MethodT
     method = Core.eval(mod, ex)
     lnn = LineNumberNode(Int(method.line), method.file)
     @test CodeTracking.definition(Expr, method) === nothing
-    CodeTracking.method_info[method.external_mt => method.sig] = [(lnn, ex)]
+    CodeTracking.invoked_setindex!(CodeTracking.method_info, [(lnn, ex)], method.external_mt => method.sig)
     @test CodeTracking.definition(Expr, method) == ex
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,8 +297,8 @@ end
 @testset "With Revise" begin
     if isdefined(Main, :Revise)
         m = @which gcd(10, 20)
-        sigs = signatures_at(Base.find_source_file(String(m.file)), m.line)
-        @test !isempty(sigs)
+        mt_sigs = signatures_at(Base.find_source_file(String(m.file)), m.line)
+        @test !isempty(mt_sigs)
         ex = @code_expr(gcd(10, 20))
         @test ex isa Expr
         body = ex.args[2]
@@ -308,10 +308,10 @@ end
 
         if Base.VERSION < v"1.11.0-0"
             m = first(methods(edit))
-            sigs = signatures_at(String(m.file), m.line)
-            @test !isempty(sigs)
-            sigs = signatures_at(Base.find_source_file(String(m.file)), m.line)
-            @test !isempty(sigs)
+            mt_sigs = signatures_at(String(m.file), m.line)
+            @test !isempty(mt_sigs)
+            mt_sigs = signatures_at(Base.find_source_file(String(m.file)), m.line)
+            @test !isempty(mt_sigs)
         end
 
         # issue #23
@@ -321,9 +321,9 @@ end
 
         if isdefined(Revise, :add_revise_deps)
             Revise.add_revise_deps()
-            sigs = signatures_at(CodeTracking, "src/utils.jl", 5)
-            @test length(sigs) == 1       # only isn't available on julia 1.0
-            (mt, sig) = first(sigs)
+            mt_sigs = signatures_at(CodeTracking, "src/utils.jl", 5)
+            @test length(mt_sigs) == 1       # only isn't available on julia 1.0
+            (mt, sig) = first(mt_sigs)
             @test sig == Tuple{typeof(CodeTracking.checkname), Expr, Any}
             @test pkgfiles(CodeTracking).id == Base.PkgId(CodeTracking)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,8 +456,6 @@ end
     @test CodeTracking.strip_gensym("𝓔′##kw") == :𝓔′
 end
 
-@static if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :(var"@MethodTable"))
-
 @testset "External method tables" begin
     mod = @eval module $(gensym(:ExternalMT))
         Base.Experimental.@MethodTable method_table
@@ -473,6 +471,4 @@ end
     @test CodeTracking.definition(Expr, method) === nothing
     CodeTracking.method_info[MethodInfoKey(method)] = [(lnn, ex)]
     @test CodeTracking.definition(Expr, method) == ex
-end
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using CodeTracking
 using Test, InteractiveUtils, REPL, LinearAlgebra, SparseArrays
 # Note: ColorTypes needs to be installed, but note the intentional absence of `using ColorTypes`
 
-using CodeTracking: line_is_decl
+using CodeTracking: line_is_decl, MethodInfoKey
 
 if !isempty(ARGS) && "revise" ∈ ARGS
     # For running tests with and without Revise
@@ -101,7 +101,7 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
 
     # Test a method marked as missing
     m = @which sum(1:5)
-    CodeTracking.invoked_setindex!(CodeTracking.method_info, missing, nothing => m.sig)
+    CodeTracking.method_info[MethodInfoKey(nothing, m.sig)] = missing
     @test whereis(m) == (CodeTracking.maybe_fix_path(String(m.file)), m.line)
     @test definition(m) === nothing
 
@@ -466,7 +466,7 @@ if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :(var"@MethodT
     method = Core.eval(mod, ex)
     lnn = LineNumberNode(Int(method.line), method.file)
     @test CodeTracking.definition(Expr, method) === nothing
-    CodeTracking.invoked_setindex!(CodeTracking.method_info, [(lnn, ex)], method.external_mt => method.sig)
+    CodeTracking.method_info[MethodInfoKey(method)] = [(lnn, ex)]
     @test CodeTracking.definition(Expr, method) == ex
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,7 +101,7 @@ isdefined(Main, :Revise) ? Main.Revise.includet("script.jl") : include("script.j
 
     # Test a method marked as missing
     m = @which sum(1:5)
-    CodeTracking.method_info[m.sig] = missing
+    CodeTracking.method_info[nothing => m.sig] = missing
     @test whereis(m) == (CodeTracking.maybe_fix_path(String(m.file)), m.line)
     @test definition(m) === nothing
 
@@ -323,7 +323,8 @@ end
             Revise.add_revise_deps()
             sigs = signatures_at(CodeTracking, "src/utils.jl", 5)
             @test length(sigs) == 1       # only isn't available on julia 1.0
-            @test first(sigs) == Tuple{typeof(CodeTracking.checkname), Expr, Any}
+            (mt, sig) = first(sigs)
+            @test sig == Tuple{typeof(CodeTracking.checkname), Expr, Any}
             @test pkgfiles(CodeTracking).id == Base.PkgId(CodeTracking)
         end
 


### PR DESCRIPTION
Modify the format of `method_info` to have it keyed by `mt::Union{Nothing, MethodTable} => sig` pairs instead of `sig`.
This allows Revise and other packages to lookup `method_info` scoped by an external method table, if any (a value of `nothing` representing the internal method table).

An alternative design would be use two dictionaries, where the current `sig => [(lnn, ex)...]` mapping would be a value of an outer `mt => info` mapping. I went with keeping a single dictionary (but modifying its key format) for simplicity, but I am open to other designs.