### PR TITLE
Tag breaking release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CodeTracking"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.0.0-DEV"
+version = "2.0.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
#140 introduced a breaking change to the `method_info` data structure, requiring a breaking release.

We had thought of deferring this breaking release until a new change to Revise that may require breaking changes. See https://github.com/timholy/Revise.jl/pull/904#issuecomment-2959251528 for context on the opening of this PR.