### PR TITLE
Slightly improve handling of `kwcall` definition lookup failure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CodeTracking"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -229,6 +229,7 @@ function definition(::Type{String}, method::Method)
         p = Base.unwrap_unionall(method.sig).parameters
         for i = 2:length(p)
             T = p[i]
+            isa(T, Core.TypeofVararg) && break # it's not our target, and there are no more arguments after this
             if T <: Function
                 mstring = string(nameof(T))
                 if startswith(mstring, '#')
@@ -237,7 +238,7 @@ function definition(::Type{String}, method::Method)
                 end
             end
         end
-        methodname == :kwcall && error("could not identify method name in `Core.kwcall`")
+        methodname == :kwcall && error("could not identify method name in `Core.kwcall` (signature: $(method.sig))")
     end
     file, line = whereis(method)
     line == 0 && return nothing


### PR DESCRIPTION
As part of Cthulhu tests, I caught an error where we try to get the definition of `kwcall` itself from https://github.com/JuliaLang/julia/blob/12f7bb52e5714c577189665a05606e3764f333cf/base/boot.jl#L366, and our handling fails thinking that it's a "wrapping" `kwcall` (and not an actual definition).

I don't think we can support parsing that well, so I just disabled that particular test in Cthulhu, but the failure mode was a bit obscure: it complained in our check `T <: Function` that `T` must be a type, and was `Vararg`, which this PR tries to make a bit clearer.

A very minor improvement, but I thought it wouldn't hurt to improve things once I figured out the reason for the subtyping check failure.